### PR TITLE
Editable Team Names

### DIFF
--- a/Scorecounter/app/src/main/java/com/example/anmol/courtcounter/Badminton/BadmintonActivity.java
+++ b/Scorecounter/app/src/main/java/com/example/anmol/courtcounter/Badminton/BadmintonActivity.java
@@ -6,10 +6,13 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProviders;
 
 import android.os.Bundle;
+import android.text.InputType;
 import android.view.View;
 import android.widget.Button;
+import android.widget.EditText;
 import android.widget.TextView;
 
+import com.example.anmol.courtcounter.Basketball.BasketballActivity;
 import com.example.anmol.courtcounter.R;
 import com.example.anmol.courtcounter.SaveResults.Result;
 import com.example.anmol.courtcounter.SaveResults.ResultViewModel;
@@ -30,6 +33,8 @@ public class BadmintonActivity extends AppCompatActivity {
     TextView gameTwoTeamB;
     TextView gameThreeTeamA;
     TextView gameThreeTeamB;
+    TextView teamAHeading;
+    TextView teamBHeading;
     Button resetButton;
     String SetOneA;
     String SetOneB;
@@ -55,13 +60,64 @@ public class BadmintonActivity extends AppCompatActivity {
         gameThreeTeamA = findViewById(R.id.game3_a);
         gameThreeTeamB = findViewById(R.id.game3_b);
         resetButton = findViewById(R.id.resetB);
-
+        teamAHeading = findViewById(R.id.TeamA_Textview);
+        teamBHeading = findViewById(R.id.TeamB_Textview);
         resetButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 resetScore();
             }
         });
+
+        teamAHeading.setOnClickListener( new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                AlertDialog.Builder alertBuilder = new AlertDialog.Builder( BadmintonActivity.this );
+                alertBuilder.setTitle( "Edit Team Name" );
+
+                final EditText input = new EditText( BadmintonActivity.this );
+                input.setInputType( InputType.TYPE_CLASS_TEXT );
+                alertBuilder.setView( input );
+                alertBuilder.setPositiveButton( "Ok", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        teamAHeading.setText( input.getText() );
+                    }
+                } );
+                alertBuilder.setNegativeButton( "Cancel", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+
+                    }
+                } );
+                alertBuilder.show();
+            }
+        } );
+
+        teamBHeading.setOnClickListener( new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                AlertDialog.Builder alertBuilder = new AlertDialog.Builder( BadmintonActivity.this );
+                alertBuilder.setTitle( "Edit Team Name" );
+
+                final EditText input = new EditText( BadmintonActivity.this );
+                input.setInputType( InputType.TYPE_CLASS_TEXT );
+                alertBuilder.setView( input );
+                alertBuilder.setPositiveButton( "Ok", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        teamBHeading.setText( input.getText() );
+                    }
+                } );
+                alertBuilder.setNegativeButton( "Cancel", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+
+                    }
+                } );
+                alertBuilder.show();
+            }
+        } );
 
     }
     public void displayScore() {

--- a/Scorecounter/app/src/main/java/com/example/anmol/courtcounter/Cricket/CricketActivity.java
+++ b/Scorecounter/app/src/main/java/com/example/anmol/courtcounter/Cricket/CricketActivity.java
@@ -7,8 +7,10 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProviders;
 
 import android.os.Bundle;
+import android.text.InputType;
 import android.view.View;
 import android.widget.Button;
+import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -47,12 +49,16 @@ public class CricketActivity extends AppCompatActivity {
     Button resButton;
     String result;
     ResultViewModel resultViewModel;
+    TextView teamAHeading;
+    TextView teamBHeading;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate( savedInstanceState );
         setContentView( R.layout.activity_cricket );
 
+        teamAHeading = findViewById(R.id.headA);
+        teamBHeading = findViewById(R.id.headB);
         resultViewModel = ViewModelProviders.of(this).get(ResultViewModel.class);
         team = getIntent().getStringExtra( "BAT_FIRST" );
         format = getIntent().getStringExtra( "MATCH_TYPE" );
@@ -81,6 +87,56 @@ public class CricketActivity extends AppCompatActivity {
         scoreTeamB = 0;
         (findViewById( R.id.team_a_ball_1 )).setBackgroundResource( R.color.colorSuccess );
         (findViewById( R.id.team_b_ball_1 )).setBackgroundResource( R.color.colorSuccess );
+
+        teamAHeading.setOnClickListener( new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                androidx.appcompat.app.AlertDialog.Builder alertBuilder = new androidx.appcompat.app.AlertDialog.Builder( CricketActivity.this );
+                alertBuilder.setTitle( "Edit Team Name" );
+
+                final EditText input = new EditText( CricketActivity.this );
+                input.setInputType( InputType.TYPE_CLASS_TEXT );
+                alertBuilder.setView( input );
+                alertBuilder.setPositiveButton( "Ok", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        teamAHeading.setText( input.getText() );
+                    }
+                } );
+                alertBuilder.setNegativeButton( "Cancel", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+
+                    }
+                } );
+                alertBuilder.show();
+            }
+        } );
+
+        teamBHeading.setOnClickListener( new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                androidx.appcompat.app.AlertDialog.Builder alertBuilder = new androidx.appcompat.app.AlertDialog.Builder( CricketActivity.this );
+                alertBuilder.setTitle( "Edit Team Name" );
+
+                final EditText input = new EditText( CricketActivity.this );
+                input.setInputType( InputType.TYPE_CLASS_TEXT );
+                alertBuilder.setView( input );
+                alertBuilder.setPositiveButton( "Ok", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        teamBHeading.setText( input.getText() );
+                    }
+                } );
+                alertBuilder.setNegativeButton( "Cancel", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+
+                    }
+                } );
+                alertBuilder.show();
+            }
+        } );
     }
 
     public void addRunsTeamA(View view) {

--- a/Scorecounter/app/src/main/java/com/example/anmol/courtcounter/Football/FootballActivity.java
+++ b/Scorecounter/app/src/main/java/com/example/anmol/courtcounter/Football/FootballActivity.java
@@ -25,6 +25,8 @@ public class FootballActivity extends AppCompatActivity {
 
     int scoreA = 0;
     int scoreB = 0;
+    TextView teamAHeading;
+    TextView teamBHeading;
     String winner = "";
     TextView scoreForTeamA;
     TextView scoreForTeamB;
@@ -68,6 +70,8 @@ public class FootballActivity extends AppCompatActivity {
         ButtonscoreA = findViewById( R.id.scoreA );
         ButtonscoreB = findViewById( R.id.scoreB );
         mediaPlayer = MediaPlayer.create( this, R.raw.tick );
+        teamAHeading = findViewById(R.id.headA);
+        teamBHeading = findViewById(R.id.headB);
 
         buttonDisablebeforeMatch();
 
@@ -153,6 +157,55 @@ public class FootballActivity extends AppCompatActivity {
                     }
                 } );
                 builder.show();
+            }
+        } );
+        teamAHeading.setOnClickListener( new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                androidx.appcompat.app.AlertDialog.Builder alertBuilder = new androidx.appcompat.app.AlertDialog.Builder( FootballActivity.this );
+                alertBuilder.setTitle( "Edit Team Name" );
+
+                final EditText input = new EditText( FootballActivity.this );
+                input.setInputType( InputType.TYPE_CLASS_TEXT );
+                alertBuilder.setView( input );
+                alertBuilder.setPositiveButton( "Ok", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        teamAHeading.setText( input.getText() );
+                    }
+                } );
+                alertBuilder.setNegativeButton( "Cancel", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+
+                    }
+                } );
+                alertBuilder.show();
+            }
+        } );
+
+        teamBHeading.setOnClickListener( new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                androidx.appcompat.app.AlertDialog.Builder alertBuilder = new androidx.appcompat.app.AlertDialog.Builder( FootballActivity.this );
+                alertBuilder.setTitle( "Edit Team Name" );
+
+                final EditText input = new EditText( FootballActivity.this );
+                input.setInputType( InputType.TYPE_CLASS_TEXT );
+                alertBuilder.setView( input );
+                alertBuilder.setPositiveButton( "Ok", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        teamBHeading.setText( input.getText() );
+                    }
+                } );
+                alertBuilder.setNegativeButton( "Cancel", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+
+                    }
+                } );
+                alertBuilder.show();
             }
         } );
     }

--- a/Scorecounter/app/src/main/java/com/example/anmol/courtcounter/Kabaddi/KabaddiActivity.java
+++ b/Scorecounter/app/src/main/java/com/example/anmol/courtcounter/Kabaddi/KabaddiActivity.java
@@ -25,6 +25,8 @@ public class KabaddiActivity extends AppCompatActivity {
 
     int scoreA = 0;
     int scoreB = 0;
+    TextView teamAHeading;
+    TextView teamBHeading;
     String winner = "";
     TextView scoreForTeamA;
     TextView scoreForTeamB;
@@ -83,6 +85,8 @@ public class KabaddiActivity extends AppCompatActivity {
         ButtonallOutA = findViewById( R.id.yellowCard_TeamA );
         ButtonallOutB = findViewById( R.id.yellowCard_TeamB );
         mediaPlayer = MediaPlayer.create( this, R.raw.tick );
+        teamAHeading = findViewById(R.id.headA);
+        teamBHeading = findViewById(R.id.headB);
         buttonDisable();
 
         mTextViewCountDown.setOnClickListener( new View.OnClickListener() {
@@ -179,6 +183,56 @@ public class KabaddiActivity extends AppCompatActivity {
             }
         } );
         updateCountDownText();
+
+        teamAHeading.setOnClickListener( new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                androidx.appcompat.app.AlertDialog.Builder alertBuilder = new androidx.appcompat.app.AlertDialog.Builder( KabaddiActivity.this );
+                alertBuilder.setTitle( "Edit Team Name" );
+
+                final EditText input = new EditText( KabaddiActivity.this );
+                input.setInputType( InputType.TYPE_CLASS_TEXT );
+                alertBuilder.setView( input );
+                alertBuilder.setPositiveButton( "Ok", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        teamAHeading.setText( input.getText() );
+                    }
+                } );
+                alertBuilder.setNegativeButton( "Cancel", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+
+                    }
+                } );
+                alertBuilder.show();
+            }
+        } );
+
+        teamBHeading.setOnClickListener( new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                androidx.appcompat.app.AlertDialog.Builder alertBuilder = new androidx.appcompat.app.AlertDialog.Builder( KabaddiActivity.this );
+                alertBuilder.setTitle( "Edit Team Name" );
+
+                final EditText input = new EditText( KabaddiActivity.this );
+                input.setInputType( InputType.TYPE_CLASS_TEXT );
+                alertBuilder.setView( input );
+                alertBuilder.setPositiveButton( "Ok", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        teamBHeading.setText( input.getText() );
+                    }
+                } );
+                alertBuilder.setNegativeButton( "Cancel", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+
+                    }
+                } );
+                alertBuilder.show();
+            }
+        } );
     }
 
     private void startTimer() {

--- a/Scorecounter/app/src/main/java/com/example/anmol/courtcounter/LawnTennis/LawnTennisActivity.java
+++ b/Scorecounter/app/src/main/java/com/example/anmol/courtcounter/LawnTennis/LawnTennisActivity.java
@@ -6,8 +6,10 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProviders;
 
 import android.os.Bundle;
+import android.text.InputType;
 import android.view.View;
 import android.widget.Button;
+import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -20,6 +22,8 @@ public class LawnTennisActivity extends AppCompatActivity {
 
     int scoreA = 0;
     int scoreB = 0;
+    TextView teamAHeading;
+    TextView teamBHeading;
     int gameA = 0;
     int gameB = 0;
     int ScoregameOneTeamB = 0;
@@ -72,7 +76,8 @@ public class LawnTennisActivity extends AppCompatActivity {
         gameFourTeamB = findViewById( R.id.game4_b );
         gameFiveTeamA = findViewById( R.id.game5_a );
         gameFiveTeamB = findViewById( R.id.game5_b );
-
+        teamAHeading = findViewById(R.id.headA);
+        teamBHeading = findViewById(R.id.headB);
         resetButton = findViewById( R.id.Reset_Button );
         resetButton.setOnClickListener( new View.OnClickListener() {
             @Override
@@ -81,6 +86,55 @@ public class LawnTennisActivity extends AppCompatActivity {
             }
         } );
 
+        teamAHeading.setOnClickListener( new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                androidx.appcompat.app.AlertDialog.Builder alertBuilder = new androidx.appcompat.app.AlertDialog.Builder( LawnTennisActivity.this );
+                alertBuilder.setTitle( "Edit Team Name" );
+
+                final EditText input = new EditText( LawnTennisActivity.this );
+                input.setInputType( InputType.TYPE_CLASS_TEXT );
+                alertBuilder.setView( input );
+                alertBuilder.setPositiveButton( "Ok", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        teamAHeading.setText( input.getText() );
+                    }
+                } );
+                alertBuilder.setNegativeButton( "Cancel", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+
+                    }
+                } );
+                alertBuilder.show();
+            }
+        } );
+
+        teamBHeading.setOnClickListener( new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                androidx.appcompat.app.AlertDialog.Builder alertBuilder = new androidx.appcompat.app.AlertDialog.Builder( LawnTennisActivity.this );
+                alertBuilder.setTitle( "Edit Team Name" );
+
+                final EditText input = new EditText( LawnTennisActivity.this );
+                input.setInputType( InputType.TYPE_CLASS_TEXT );
+                alertBuilder.setView( input );
+                alertBuilder.setPositiveButton( "Ok", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        teamBHeading.setText( input.getText() );
+                    }
+                } );
+                alertBuilder.setNegativeButton( "Cancel", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+
+                    }
+                } );
+                alertBuilder.show();
+            }
+        } );
     }
 
     public void displayScore() {

--- a/Scorecounter/app/src/main/java/com/example/anmol/courtcounter/TableTennis/TableTennisAcitivity.java
+++ b/Scorecounter/app/src/main/java/com/example/anmol/courtcounter/TableTennis/TableTennisAcitivity.java
@@ -6,8 +6,10 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProviders;
 
 import android.os.Bundle;
+import android.text.InputType;
 import android.view.View;
 import android.widget.Button;
+import android.widget.EditText;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
@@ -23,7 +25,8 @@ public class TableTennisAcitivity extends AppCompatActivity {
     int gameB = 0;
     int resetCounter = 0;
     String winner="";
-
+    TextView teamAHeading;
+    TextView teamBHeading;
     TextView scoreForTeamA;
     TextView scoreForTeamB;
     TextView gameOneTeamA;
@@ -71,7 +74,8 @@ public class TableTennisAcitivity extends AppCompatActivity {
         gameFourTeamB = findViewById(R.id.game4_b);
         gameFiveTeamA = findViewById(R.id.game5_a);
         gameFiveTeamB = findViewById(R.id.game5_b);
-
+        teamAHeading = findViewById(R.id.headA);
+        teamBHeading = findViewById(R.id.headB);
       resetButton = findViewById(R.id.Reset_Button);
        resetButton.setOnClickListener(new View.OnClickListener() {
            @Override
@@ -80,6 +84,55 @@ public class TableTennisAcitivity extends AppCompatActivity {
             }
         });
 
+        teamAHeading.setOnClickListener( new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                androidx.appcompat.app.AlertDialog.Builder alertBuilder = new androidx.appcompat.app.AlertDialog.Builder( TableTennisAcitivity.this );
+                alertBuilder.setTitle( "Edit Team Name" );
+
+                final EditText input = new EditText( TableTennisAcitivity.this );
+                input.setInputType( InputType.TYPE_CLASS_TEXT );
+                alertBuilder.setView( input );
+                alertBuilder.setPositiveButton( "Ok", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        teamAHeading.setText( input.getText() );
+                    }
+                } );
+                alertBuilder.setNegativeButton( "Cancel", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+
+                    }
+                } );
+                alertBuilder.show();
+            }
+        } );
+
+        teamBHeading.setOnClickListener( new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                androidx.appcompat.app.AlertDialog.Builder alertBuilder = new androidx.appcompat.app.AlertDialog.Builder( TableTennisAcitivity.this );
+                alertBuilder.setTitle( "Edit Team Name" );
+
+                final EditText input = new EditText( TableTennisAcitivity.this );
+                input.setInputType( InputType.TYPE_CLASS_TEXT );
+                alertBuilder.setView( input );
+                alertBuilder.setPositiveButton( "Ok", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        teamBHeading.setText( input.getText() );
+                    }
+                } );
+                alertBuilder.setNegativeButton( "Cancel", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+
+                    }
+                } );
+                alertBuilder.show();
+            }
+        } );
     }
     public void displayScore() {
         scoreForTeamA.setText(String.valueOf(scoreA));

--- a/Scorecounter/app/src/main/res/layout/activity_badminton.xml
+++ b/Scorecounter/app/src/main/res/layout/activity_badminton.xml
@@ -22,6 +22,7 @@
                 <LinearLayout style="@style/LinearColumn">
 
                     <TextView
+                        android:id="@+id/TeamA_Textview"
                         style="@style/headings"
                         android:text="@string/team_a"
                         android:textColor="@color/headingBlue" />
@@ -43,6 +44,7 @@
                 <LinearLayout style="@style/LinearColumn">
 
                     <TextView
+                        android:id="@+id/TeamB_Textview"
                         style="@style/headings"
                         android:text="@string/team_b"
                         android:textColor="@color/headingRed" />

--- a/Scorecounter/app/src/main/res/layout/activity_cricket.xml
+++ b/Scorecounter/app/src/main/res/layout/activity_cricket.xml
@@ -23,6 +23,7 @@
                 <LinearLayout style="@style/LinearColumn">
 
                     <TextView
+                        android:id="@+id/headA"
                         style="@style/headings"
                         android:text="@string/team_a"
                         android:textColor="@color/headingBlue" />
@@ -281,6 +282,7 @@
                 <LinearLayout style="@style/LinearColumn">
 
                     <TextView
+                        android:id="@+id/headB"
                         style="@style/headings"
                         android:text="@string/team_b"
                         android:textColor="@color/headingRed" />

--- a/Scorecounter/app/src/main/res/layout/activity_football.xml
+++ b/Scorecounter/app/src/main/res/layout/activity_football.xml
@@ -25,6 +25,7 @@
                 <LinearLayout style="@style/LinearColumn">
 
                     <TextView
+                        android:id="@+id/headA"
                         style="@style/headings"
                         android:text="@string/team_a"
                         android:textColor="@color/headingBlue" />
@@ -61,6 +62,7 @@
                 <LinearLayout style="@style/LinearColumn">
 
                     <TextView
+                        android:id="@+id/headB"
                         style="@style/headings"
                         android:text="@string/team_b"
                         android:textColor="@android:color/holo_green_dark" />

--- a/Scorecounter/app/src/main/res/layout/activity_kabaddi.xml
+++ b/Scorecounter/app/src/main/res/layout/activity_kabaddi.xml
@@ -25,6 +25,7 @@
                 <LinearLayout style="@style/LinearColumn">
 
                     <TextView
+                        android:id="@+id/headA"
                         style="@style/headings"
                         android:text="@string/team_a"
                         android:textColor="@color/headingBlue" />
@@ -69,6 +70,7 @@
                 <LinearLayout style="@style/LinearColumn">
 
                     <TextView
+                        android:id="@+id/headB"
                         style="@style/headings"
                         android:text="@string/team_b"
                         android:textColor="@android:color/holo_green_dark" />

--- a/Scorecounter/app/src/main/res/layout/activity_lawn_tennis.xml
+++ b/Scorecounter/app/src/main/res/layout/activity_lawn_tennis.xml
@@ -25,6 +25,7 @@
                     <LinearLayout style="@style/LinearColumn">
 
                         <TextView
+                            android:id="@+id/headA"
                             style="@style/headings"
                             android:text="@string/team_a"
                             android:textColor="@color/headingBlue" />
@@ -46,6 +47,7 @@
                     <LinearLayout style="@style/LinearColumn">
 
                         <TextView
+                            android:id="@+id/headB"
                             style="@style/headings"
                             android:text="@string/team_b"
                             android:textColor="@color/headingRed" />

--- a/Scorecounter/app/src/main/res/layout/activity_table_tennis_acitivity.xml
+++ b/Scorecounter/app/src/main/res/layout/activity_table_tennis_acitivity.xml
@@ -24,6 +24,7 @@
                     <LinearLayout style="@style/LinearColumn">
 
                         <TextView
+                            android:id="@+id/headA"
                             style="@style/headings"
                             android:text="@string/team_a"
                             android:textColor="@color/headingBlue" />
@@ -45,6 +46,7 @@
                     <LinearLayout style="@style/LinearColumn">
 
                         <TextView
+                            android:id="@+id/headB"
                             style="@style/headings"
                             android:text="@string/team_b"
                             android:textColor="@color/headingRed" />


### PR DESCRIPTION
Don't delete anything without explicit instructions from a maintainer.

#### Check by changing each `[ ]` to `[x]`

[x] Read and understood the code.

[x] Included a description of change below.

[x] Included screenshot(s)/link showing after and before the changes.

[x] Tried to squash the commits.


#### Changes done in this Pull Request
Fixes #94 
Added Alert boxes which prompt change of team name upon clicking of the Team titles in all the games.

#### Screenshots showing changes before and after the changes : GIF attached
![Screenrecorder-2020-01-01-16-36-40-450](https://user-images.githubusercontent.com/53938155/71640756-2f73a700-2cb6-11ea-81c7-0ad979171034.gif)


#### The problem I want to solve or the facility I want to improve further is
The team names couldn't be edited in Badminton, Table Tennis, Lawn Tennis, Cricket, Football and Kabaddi. 
Now after this, they can be. 
#### My steps to solve it are
Added on click listeners to the textviews which prompt team name change, to be typed in the alert box. 

