### PR TITLE
Red and Yellow Card Buttons.

### DIFF
--- a/Scorecounter/app/src/main/java/com/example/anmol/courtcounter/Football/FootballActivity.java
+++ b/Scorecounter/app/src/main/java/com/example/anmol/courtcounter/Football/FootballActivity.java
@@ -32,10 +32,6 @@ public class FootballActivity extends AppCompatActivity {
     TextView scoreForTeamB;
     Button finishButton;
     Button reset;
-    Button redCard_teamA;
-    Button redCard_teamB;
-    Button yellowCard_teamA;
-    Button yellowCard_teamB;
     Button ButtonscoreA;
     Button ButtonscoreB;
     private TextView redA;
@@ -65,10 +61,7 @@ public class FootballActivity extends AppCompatActivity {
         scoreForTeamB = findViewById( R.id.team_b_score );
         finishButton = findViewById( R.id.finish );
         reset = findViewById( R.id.reset );
-        redCard_teamA = findViewById( R.id.redCard_TeamA );
-        redCard_teamB = findViewById( R.id.redCard_TeamB );
-        yellowCard_teamA = findViewById( R.id.yellowCard_TeamA );
-        yellowCard_teamB = findViewById( R.id.yellowCard_TeamB );
+
         mTextViewCountDown = findViewById( R.id.text_view_countdown );
         mButtonStartPause = findViewById( R.id.button_start_pause );
         ButtonscoreA = findViewById( R.id.scoreA );
@@ -83,28 +76,28 @@ public class FootballActivity extends AppCompatActivity {
 
         buttonDisablebeforeMatch();
 
-        redCard_teamA.setOnClickListener( new View.OnClickListener() {
+        redA.setOnClickListener( new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 redCardA();
             }
         } );
 
-        redCard_teamB.setOnClickListener( new View.OnClickListener() {
+        redB.setOnClickListener( new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 redCardB();
             }
         } );
 
-        yellowCard_teamA.setOnClickListener( new View.OnClickListener() {
+        yellowA.setOnClickListener( new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 yellowCardA();
             }
         } );
 
-        yellowCard_teamB.setOnClickListener( new View.OnClickListener() {
+        yellowB.setOnClickListener( new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 yellowCardB();
@@ -296,6 +289,10 @@ public class FootballActivity extends AppCompatActivity {
         mTimeLeftInMillis = START_TIME_IN_MILLIS;
         updateCountDownText();
         buttonDisablebeforeMatch();
+        redA.setText("");
+        redB.setText("");
+        yellowA.setText("");
+        yellowB.setText("");
     }
 
     public void Alert() {
@@ -373,23 +370,22 @@ public class FootballActivity extends AppCompatActivity {
 
     public void buttonDisablebeforeMatch() {
 
-        redCard_teamA.setEnabled( false );
-        redCard_teamB.setEnabled( false );
-        yellowCard_teamA.setEnabled( false );
-        yellowCard_teamB.setEnabled( false );
         ButtonscoreA.setEnabled( false );
         ButtonscoreB.setEnabled( false );
-
+        redA.setEnabled(false);
+        redB.setEnabled(false);
+        yellowA.setEnabled(false);
+        yellowB.setEnabled(false);
     }
 
     public void buttonEnable() {
 
-        redCard_teamA.setEnabled( true );
-        redCard_teamB.setEnabled( true );
-        yellowCard_teamA.setEnabled( true );
-        yellowCard_teamB.setEnabled( true );
         ButtonscoreA.setEnabled( true );
         ButtonscoreB.setEnabled( true );
+        redA.setEnabled(true);
+        redB.setEnabled(true);
+        yellowA.setEnabled(true);
+        yellowB.setEnabled(true);
 
     }
 

--- a/Scorecounter/app/src/main/res/layout/activity_football.xml
+++ b/Scorecounter/app/src/main/res/layout/activity_football.xml
@@ -74,17 +74,6 @@
                         android:onClick="teamAScore"
                         android:text="@string/add_one_point" />
 
-                    <Button
-                        android:id="@+id/redCard_TeamA"
-                        style="@style/button"
-                        android:background="@drawable/rounded_button_red"
-                        android:text="@string/redCard" />
-
-                    <Button
-                        android:id="@+id/yellowCard_TeamA"
-                        style="@style/button"
-                        android:background="@drawable/rounded_button_yellow"
-                        android:text="@string/yellowCard" />
 
 
                 </LinearLayout>
@@ -140,17 +129,6 @@
                         android:onClick="teamBScore"
                         android:text="@string/add_one_point" />
 
-                    <Button
-                        android:id="@+id/redCard_TeamB"
-                        style="@style/button"
-                        android:background="@drawable/rounded_button_red"
-                        android:text="@string/redCard" />
-
-                    <Button
-                        android:id="@+id/yellowCard_TeamB"
-                        style="@style/button"
-                        android:background="@drawable/rounded_button_yellow"
-                        android:text="@string/yellowCard" />
                 </LinearLayout>
             </LinearLayout>
 


### PR DESCRIPTION
Don't delete anything without explicit instructions from a maintainer.

#### Check by changing each `[ ]` to `[x]`

[x] Read and understood the code.

[x] Included a description of change below.

[x] Included screenshot(s)/link showing after and before the changes.

[x] Tried to squash the commits.


#### Changes done in this Pull Request

Fixes #101 

#### The problem I want to solve or the facility I want to improve further is/are
The red and yellow card views should add the red and yellow cards instead of having separate buttons for them.

#### My steps to solve it would be
-Setting on click listeners on those textviews and handle card addition.
-Removing the existing buttons
-Editing the disabled and enabled functions to disable those textviews before the start of match and enabling during the game.
-Editing the reset function to reset the textviews as well.

#### Screenshots showing changes before and after the changes
![Screenrecorder-2020-01-05-19-50-48-572](https://user-images.githubusercontent.com/53938155/71781460-41768200-2ff5-11ea-9714-899c0470da6d.gif)


