### PR TITLE
Settings Menu Option Bug. 

### DIFF
--- a/Scorecounter/app/src/main/res/menu/main_menu.xml
+++ b/Scorecounter/app/src/main/res/menu/main_menu.xml
@@ -7,10 +7,7 @@
         android:icon="@drawable/ic_info_outline_24dp"
         android:title="@string/menu_about"
         app:showAsAction="never" />
-    <item
-        android:id="@+id/action_settings"
-        android:title="@string/menu_setting"
-        app:showAsAction="never" />
+
     <item android:id="@+id/action_savedResults"
         android:title="@string/savedResults"
         app:showAsAction="never"/>


### PR DESCRIPTION
Don't delete anything without explicit instructions from a maintainer.

#### Check by changing each `[ ]` to `[x]`

[x] Read and understood the code.

[x] Included a description of change below.

[x] Included screenshot(s)/link showing after and before the changes.

[x] Tried to squash the commits.


#### Changes done in this Pull Request

Fixes #105 

#### Screenshots showing changes before and after the changes
Before - 
![Screenshot_2020-01-06-02-03-31-153_com example anmol courtcounter](https://user-images.githubusercontent.com/53938155/71785733-27569700-3029-11ea-8704-f5794fbde580.png)
After - 
![Screenshot_2020-01-06-02-04-42-220_com example anmol courtcounter](https://user-images.githubusercontent.com/53938155/71785734-27ef2d80-3029-11ea-8ce9-37f0d7a482dd.png)


#### The problem I want to solve or the facility I want to improve further is/are
The non-working settings menu option should be removed. 

#### My steps to solve it would be
Removing the menu option 